### PR TITLE
Make encounter generation over 100x faster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+dnd-randomizer.code-workspace


### PR DESCRIPTION
Previously it was doing fuzzy matching when it was creating any item, regardless of whether it was necessary or not. Try and do exact match with id before attempting a fuzzy match. 

Fix #35 