### PR TITLE
Add logic to show an alert if an encounter formula is impossible

### DIFF
--- a/scripts/dialog.js
+++ b/scripts/dialog.js
@@ -7,7 +7,7 @@ import { SFLOCALCONSTS } from "./localconst.js";
 import { SFCONSTS } from "./main.js";
 import { EncounterUtilsPf2e } from "./pf2e/EncounterUtilsPf2e.js";
 import { ActorUtils } from "./utils/ActorUtils.js";
-
+import { EncounterUtils } from "./utils/EncounterUtils.js";
 export class SFDialog extends FormApplication
 {
 	constructor()
@@ -336,13 +336,40 @@ export class SFDialog extends FormApplication
 				averageLevelOfPlayers = html.find('#averageLevelOfPlayers select[name="averageLevelOfPlayers"]').val();
 			}
 
+			const encounterType = html.find('#encounterTypeSpan select[id="encounterTypeSelect"]').val();
 			const params = {
 				loot_type: html.find('#lootType select[name="lootType"]').val(),
-				encounterType: html.find('#encounterTypeSpan select[id="encounterTypeSelect"]').val(),
+				encounterType: encounterType,
 				creatureTypeVariety: html.find('#creatureTypeVariationSpan select[id="creatureTypeVariationSelect"]').val(),
 				numberOfPlayers: numberOfPlayers,
 				averageLevelOfPlayers: averageLevelOfPlayers
 			};
+
+			let encounterTypeInformation = SFLOCALCONSTS.PF2E_ENCOUNTER_TYPE_DESCRIPTIONS[encounterType];
+
+			const isEncounterFormulaPossible = EncounterUtils.isEncounterFormulaPossibleForPlayers(encounterTypeInformation, averageLevelOfPlayers);
+
+			if (!isEncounterFormulaPossible)
+			{
+				let d = new Dialog({
+					title: "Encounter Alert",
+					content: "<p>The encounter type chosen is impossible for your current average player level. Please choose another type or check the console for more information.</p>",
+					buttons: {
+					 one: {
+					  icon: '<i class="fas fa-check"></i>',
+					  label: "OK",
+					  callback: () => console.log("Dialog dismissed")
+					 }
+					},
+					default: "one",
+					render: html => console.log("Alert dialog rendered"),
+					close: html => console.log("Alert dialog closed")
+				});
+				d.render(true);
+				$button.prop('disabled', false).removeClass('disabled');
+				$button.find('i.fas').removeClass('fa-spinner fa-spin').addClass('fa-dice');
+				return;
+			}
 
 			let forceReload = false;
 			await SFLocalHelpers.populateObjectsFromCompendiums(forceReload);

--- a/scripts/dnd5e/EncounterUtils5e.js
+++ b/scripts/dnd5e/EncounterUtils5e.js
@@ -662,5 +662,8 @@ export class EncounterUtils5e
     }
   }
 
-  static getCRFromXP
+  static isEncounterFormulaPossibleForPlayers(encounterFormula, averageLevelOfPlayers)
+  {
+    return true;
+  }
 }

--- a/scripts/pf2e/EncounterUtilsPf2e.js
+++ b/scripts/pf2e/EncounterUtilsPf2e.js
@@ -3,239 +3,259 @@ import { SFLOCALCONSTS } from "../localconst.js";
 import { SFLocalHelpers } from "../localmodule.js";
 export class EncounterUtilsPf2e
 {
-    static async createEncounterPf2e(monsterList, itemList, averageLevelOfPlayers, numberOfPlayers, params)
+  static async createEncounterPf2e(monsterList, itemList, averageLevelOfPlayers, numberOfPlayers, params)
+  {
+    let currentEncounter = {};
+    currentEncounter["creatures"] = [];
+    let currentEncounterXP = 0;
+    let numberOfMonstersInCombat = 0;
+    let encounterType = params.encounterType;
+    let isSingleCreatureTypeVariety = params.creatureTypeVariety.toLowerCase() === "single";
+    let singleCreatureType = null;
+    let encounterTypeInformation = SFLOCALCONSTS.PF2E_ENCOUNTER_TYPE_DESCRIPTIONS[encounterType];
+    let currentEncounterDifficulty = encounterTypeInformation.EncounterDifficulty;
+    currentEncounter["difficulty"] = currentEncounterDifficulty;
+    let currentEncounterFormula = encounterTypeInformation.EncounterFormula;
+    let amountToAdjustEncounter = 0;
+    currentEncounter["unfilledformula"] = [];
+
+    for (var i = 0; i < currentEncounterFormula.length; i++)
     {
-      let currentEncounter = {};
-      currentEncounter["creatures"] = [];
-      let currentEncounterXP = 0;
-      let numberOfMonstersInCombat = 0;
-      let encounterType = params.encounterType;
-      let isSingleCreatureTypeVariety = params.creatureTypeVariety.toLowerCase() === "single";
-      let singleCreatureType = null;
-      let encounterTypeInformation = SFLOCALCONSTS.PF2E_ENCOUNTER_TYPE_DESCRIPTIONS[encounterType];
-      let currentEncounterDifficulty = encounterTypeInformation.EncounterDifficulty;
-      currentEncounter["difficulty"] = currentEncounterDifficulty;
-      let currentEncounterFormula = encounterTypeInformation.EncounterFormula;
-      let amountToAdjustEncounter = 0;
-      currentEncounter["unfilledformula"] = [];
+      let currentEncounterDescription = currentEncounterFormula[i];
+      
+      let targetEncounterDifficultyInformation = SFLOCALCONSTS.PATHFINDER_2E_ENCOUNTER_BUDGET[currentEncounterDifficulty];
+      let originalTargetEncounterXP = targetEncounterDifficultyInformation[0];
+      let characterAdjustment = targetEncounterDifficultyInformation[1];
+      amountToAdjustEncounter = (numberOfPlayers - 4) * characterAdjustment;
+      let creatureDescriptionParts = currentEncounterDescription.split(":");
 
-      for (var i = 0; i < currentEncounterFormula.length; i++)
+      if (creatureDescriptionParts.length != 2)
       {
-        let currentEncounterDescription = currentEncounterFormula[i];
-        
-        let targetEncounterDifficultyInformation = SFLOCALCONSTS.PATHFINDER_2E_ENCOUNTER_BUDGET[currentEncounterDifficulty];
-        let originalTargetEncounterXP = targetEncounterDifficultyInformation[0];
-        let characterAdjustment = targetEncounterDifficultyInformation[1];
-        amountToAdjustEncounter = (numberOfPlayers - 4) * characterAdjustment;
-        let creatureDescriptionParts = currentEncounterDescription.split(":");
+        console.error(`Encounter type description is invalid. Expected format of number:formula. For example: 2:0.3*x. This would choose 2 creatures that are roughly near 30% of the the target encounter XP. Actual: ${currentEncounterDescription}`);
+        return;
+      }
+      let numberOfCreatures = creatureDescriptionParts[0];
+      let levelInRelationToParty = creatureDescriptionParts[1];
 
-        if (creatureDescriptionParts.length != 2)
-        {
-          console.error(`Encounter type description is invalid. Expected format of number:formula. For example: 2:0.3*x. This would choose 2 creatures that are roughly near 30% of the the target encounter XP. Actual: ${currentEncounterDescription}`);
-          return;
-        }
-        let numberOfCreatures = creatureDescriptionParts[0];
-        let levelInRelationToParty = creatureDescriptionParts[1];
+      const expectedMonsterLevel = parseInt(averageLevelOfPlayers) +  parseInt(levelInRelationToParty);
+      let filteredMonsterList = monsterList.filter(m => FoundryUtils.getDataObjectFromObject(m.actor).details.level.value === expectedMonsterLevel);
+      if (filteredMonsterList.length === 0)
+      {
+        console.warn(`Unable to find monsters for the current requested level configuration: ${expectedMonsterLevel}`);
+        let unfilledFormula = {};
+        unfilledFormula["formula"] = currentEncounterDescription;
+        unfilledFormula["targetmonsterlevel"] = expectedMonsterLevel;
+        unfilledFormula["numberofcreatures"] = numberOfCreatures;
+        currentEncounter["unfilledformula"].push(unfilledFormula);
+        continue;
+      }
 
-        const expectedMonsterLevel = parseInt(averageLevelOfPlayers) +  parseInt(levelInRelationToParty);
-        let filteredMonsterList = monsterList.filter(m => FoundryUtils.getDataObjectFromObject(m.actor).details.level.value === expectedMonsterLevel);
-        if (filteredMonsterList.length === 0)
+      let randomMonsterIndex = Math.floor((Math.random() * filteredMonsterList.length));
+      let randomMonster = filteredMonsterList[randomMonsterIndex];
+      let randomMonsterActorObj = randomMonster.actor;
+      let monsterName = randomMonster.actorname;
+
+      if (singleCreatureType != null && singleCreatureType != randomMonster.creaturetype)
+      {
+        console.log(`Skipping creature ${monsterName}, id ${randomMonster.actorid} b/c not same creature type ${singleCreatureType} as previous monster.`);
+        let unfilledFormula = {};
+        unfilledFormula["formula"] = currentEncounterDescription;
+        unfilledFormula["targetmonsterlevel"] = expectedMonsterLevel;
+        unfilledFormula["numberofcreatures"] = numberOfCreatures;
+        currentEncounter["unfilledformula"].push(unfilledFormula);
+        continue;
+      }
+      let randomMonsterLevel = FoundryUtils.getDataObjectFromObject(randomMonsterActorObj).details.level.value;
+      let creatureCombatDetails = {};
+      creatureCombatDetails["name"] = monsterName;
+      creatureCombatDetails["actorid"] = randomMonster.actorid;
+      creatureCombatDetails["compendiumname"] = randomMonster.compendiumname;
+      creatureCombatDetails["quantity"] = numberOfCreatures;
+      creatureCombatDetails["level"] = randomMonsterLevel;
+
+      // Lock in the current creature type value
+      if (isSingleCreatureTypeVariety && singleCreatureType === null)
+      {
+        singleCreatureType = randomMonster.creaturetype;
+      }
+
+      currentEncounter["creatures"].push(creatureCombatDetails);
+    }
+
+    currentEncounter["level"] = averageLevelOfPlayers;
+    let generatedLootObject = EncounterUtilsPf2e.getPF2ELootForEncounter(currentEncounter, itemList, params);
+    currentEncounter["loot"] = generatedLootObject;
+    currentEncounter["amounttoadjustencounter"] = amountToAdjustEncounter;
+    return currentEncounter;
+  }
+
+  static getPF2ELootForEncounter(currentEncounter, itemList, params)
+  {
+    let lootType = params.loot_type;
+    let currencyTable = SFLOCALCONSTS.PF2E_CURRENCY_TABLE;
+    let encounterLevel = currentEncounter["level"];
+    let encounterDifficulty = currentEncounter["difficulty"];
+    let currencyList = currencyTable[encounterLevel];
+    let goldPieces = 0;
+    switch (encounterDifficulty)
+    {
+      case "Low":
+        goldPieces = currencyList[0];
+        break;
+      case "Moderate":
+        goldPieces = currencyList[1];
+        break;
+      case "Severe":
+        goldPieces = currencyList[2];
+        break;
+      case "Extreme":
+        goldPieces = currencyList[3];
+        break;
+    }
+
+    let lootResultObject = {};
+    let currencyResultObject = {};
+    let itemsResultObject = EncounterUtilsPf2e.getPF2EItemLootForEncounter(itemList, goldPieces, encounterLevel, lootType);
+
+    currencyResultObject["pp"] = 0;
+    currencyResultObject["gp"] = goldPieces;
+    currencyResultObject["sp"] = 0;
+    currencyResultObject["cp"] = 0;
+
+    for (let item of itemsResultObject)
+    {
+      currencyResultObject = EncounterUtilsPf2e.subtractCurrencyAmount(currencyResultObject, item.object.itemcost);
+    }
+
+    let otherResultObject = [];
+    let scrollsResultObject = [];
+    lootResultObject["currency"] = currencyResultObject;
+    lootResultObject["items"] = itemsResultObject;
+    lootResultObject["other"] = otherResultObject;
+    lootResultObject["scrolls"] = scrollsResultObject;
+    return lootResultObject;
+  }
+
+  static subtractCurrencyAmount(currencyObject, subtractionAmount)
+  {
+    let currentAmountTotal = EncounterUtilsPf2e.getTotalGoldCostFromCostObject(currencyObject);
+    let subtractionAmountTotal = EncounterUtilsPf2e.getTotalGoldCostFromCostObject(subtractionAmount);
+
+    if (subtractionAmountTotal > currentAmountTotal)
+    {
+      throw new Error(`Subtraction amount ${subtractionAmountTotal} was larger than total amount ${currentAmountTotal}`);
+    }
+
+    let leftOverCurerncy = currentAmountTotal - subtractionAmountTotal;
+
+    let currencyResultObject = {};
+    currencyResultObject["pp"] = 0;
+    currencyResultObject["gp"] = leftOverCurerncy - leftOverCurerncy % 1;
+    leftOverCurerncy -= currencyResultObject["gp"];
+    leftOverCurerncy *= 10;
+    currencyResultObject["sp"] = leftOverCurerncy - leftOverCurerncy % 1;
+    leftOverCurerncy -= currencyResultObject["sp"];
+    leftOverCurerncy *= 10;
+    currencyResultObject["cp"] = leftOverCurerncy - leftOverCurerncy % 1;
+    return currencyResultObject;
+  }
+
+  static getPF2EItemLootForEncounter(itemList, goldPieces, encounterLevel, lootType)
+  {
+    let itemsResultObject = [];
+    let itemCount = 0;
+    let goldPiecesLeft = goldPieces;
+    if (lootType === "Individual Treasure")
+    {
+      itemCount = 1;
+    }
+    else
+    {
+      itemCount = FoundryUtils.getRollResult("2d4");
+    }
+
+    for (let i = 0; i < itemCount; i++)
+    {
+      // Leave at least 10 gp left
+      if (goldPiecesLeft < 10)
+      {
+        break;
+      }
+
+      let j = 0;
+      while (j < 50) // attempt to put in 50 items before giving up so we don't spin forever
+      {
+        j++;
+        let randomItemIndex = Math.floor((Math.random() * itemList.length));
+        let randomItemObject = itemList[randomItemIndex];
+        let itemType = randomItemObject.itemtype;
+        let itemLevel = randomItemObject.level;
+        let itemCost = randomItemObject.itemcost;
+        let itemName = randomItemObject.itemname;
+        let item = randomItemObject.item;
+
+        let totalGoldCost = EncounterUtilsPf2e.getTotalGoldCostFromCostObject(itemCost.value);
+
+        if (totalGoldCost === 0)
         {
-          console.warn(`Unable to find monsters for the current requested level configuration: ${expectedMonsterLevel}`);
-          let unfilledFormula = {};
-          unfilledFormula["formula"] = currentEncounterDescription;
-          unfilledFormula["targetmonsterlevel"] = expectedMonsterLevel;
-          unfilledFormula["numberofcreatures"] = numberOfCreatures;
-          currentEncounter["unfilledformula"].push(unfilledFormula);
+          // ignore treasure with 0 cost
           continue;
         }
 
-        let randomMonsterIndex = Math.floor((Math.random() * filteredMonsterList.length));
-        let randomMonster = filteredMonsterList[randomMonsterIndex];
-        let randomMonsterActorObj = randomMonster.actor;
-        let monsterName = randomMonster.actorname;
-
-        if (singleCreatureType != null && singleCreatureType != randomMonster.creaturetype)
+        if (totalGoldCost <= goldPiecesLeft)
         {
-          console.log(`Skipping creature ${monsterName}, id ${randomMonster.actorid} b/c not same creature type ${singleCreatureType} as previous monster.`);
-          let unfilledFormula = {};
-          unfilledFormula["formula"] = currentEncounterDescription;
-          unfilledFormula["targetmonsterlevel"] = expectedMonsterLevel;
-          unfilledFormula["numberofcreatures"] = numberOfCreatures;
-          currentEncounter["unfilledformula"].push(unfilledFormula);
-          continue;
-        }
-        let randomMonsterLevel = FoundryUtils.getDataObjectFromObject(randomMonsterActorObj).details.level.value;
-        let creatureCombatDetails = {};
-        creatureCombatDetails["name"] = monsterName;
-        creatureCombatDetails["actorid"] = randomMonster.actorid;
-        creatureCombatDetails["compendiumname"] = randomMonster.compendiumname;
-        creatureCombatDetails["quantity"] = numberOfCreatures;
-        creatureCombatDetails["level"] = randomMonsterLevel;
-
-        // Lock in the current creature type value
-        if (isSingleCreatureTypeVariety && singleCreatureType === null)
-        {
-          singleCreatureType = randomMonster.creaturetype;
-        }
-
-        currentEncounter["creatures"].push(creatureCombatDetails);
-      }
-
-      currentEncounter["level"] = averageLevelOfPlayers;
-      let generatedLootObject = EncounterUtilsPf2e.getPF2ELootForEncounter(currentEncounter, itemList, params);
-      currentEncounter["loot"] = generatedLootObject;
-      currentEncounter["amounttoadjustencounter"] = amountToAdjustEncounter;
-      return currentEncounter;
-    }
-
-    static getPF2ELootForEncounter(currentEncounter, itemList, params)
-    {
-      let lootType = params.loot_type;
-      let currencyTable = SFLOCALCONSTS.PF2E_CURRENCY_TABLE;
-      let encounterLevel = currentEncounter["level"];
-      let encounterDifficulty = currentEncounter["difficulty"];
-      let currencyList = currencyTable[encounterLevel];
-      let goldPieces = 0;
-      switch (encounterDifficulty)
-      {
-        case "Low":
-          goldPieces = currencyList[0];
-          break;
-        case "Moderate":
-          goldPieces = currencyList[1];
-          break;
-        case "Severe":
-          goldPieces = currencyList[2];
-          break;
-        case "Extreme":
-          goldPieces = currencyList[3];
-          break;
-      }
-
-      let lootResultObject = {};
-      let currencyResultObject = {};
-      let itemsResultObject = EncounterUtilsPf2e.getPF2EItemLootForEncounter(itemList, goldPieces, encounterLevel, lootType);
-
-      currencyResultObject["pp"] = 0;
-      currencyResultObject["gp"] = goldPieces;
-      currencyResultObject["sp"] = 0;
-      currencyResultObject["cp"] = 0;
-
-      for (let item of itemsResultObject)
-      {
-        currencyResultObject = EncounterUtilsPf2e.subtractCurrencyAmount(currencyResultObject, item.object.itemcost);
-      }
-
-      let otherResultObject = [];
-      let scrollsResultObject = [];
-      lootResultObject["currency"] = currencyResultObject;
-      lootResultObject["items"] = itemsResultObject;
-      lootResultObject["other"] = otherResultObject;
-      lootResultObject["scrolls"] = scrollsResultObject;
-      return lootResultObject;
-    }
-
-    static subtractCurrencyAmount(currencyObject, subtractionAmount)
-    {
-      let currentAmountTotal = EncounterUtilsPf2e.getTotalGoldCostFromCostObject(currencyObject);
-      let subtractionAmountTotal = EncounterUtilsPf2e.getTotalGoldCostFromCostObject(subtractionAmount);
-
-      if (subtractionAmountTotal > currentAmountTotal)
-      {
-        throw new Error(`Subtraction amount ${subtractionAmountTotal} was larger than total amount ${currentAmountTotal}`);
-      }
-
-      let leftOverCurerncy = currentAmountTotal - subtractionAmountTotal;
-
-      let currencyResultObject = {};
-      currencyResultObject["pp"] = 0;
-      currencyResultObject["gp"] = leftOverCurerncy - leftOverCurerncy % 1;
-      leftOverCurerncy -= currencyResultObject["gp"];
-      leftOverCurerncy *= 10;
-      currencyResultObject["sp"] = leftOverCurerncy - leftOverCurerncy % 1;
-      leftOverCurerncy -= currencyResultObject["sp"];
-      leftOverCurerncy *= 10;
-      currencyResultObject["cp"] = leftOverCurerncy - leftOverCurerncy % 1;
-      return currencyResultObject;
-    }
-
-    static getPF2EItemLootForEncounter(itemList, goldPieces, encounterLevel, lootType)
-    {
-      let itemsResultObject = [];
-      let itemCount = 0;
-      let goldPiecesLeft = goldPieces;
-      if (lootType === "Individual Treasure")
-      {
-        itemCount = 1;
-      }
-      else
-      {
-        itemCount = FoundryUtils.getRollResult("2d4");
-      }
-
-      for (let i = 0; i < itemCount; i++)
-      {
-        // Leave at least 10 gp left
-        if (goldPiecesLeft < 10)
-        {
-          break;
-        }
-
-        let j = 0;
-        while (j < 50) // attempt to put in 50 items before giving up so we don't spin forever
-        {
-          j++;
-          let randomItemIndex = Math.floor((Math.random() * itemList.length));
-          let randomItemObject = itemList[randomItemIndex];
-          let itemType = randomItemObject.itemtype;
-          let itemLevel = randomItemObject.level;
-          let itemCost = randomItemObject.itemcost;
-          let itemName = randomItemObject.itemname;
-          let item = randomItemObject.item;
-
-          let totalGoldCost = EncounterUtilsPf2e.getTotalGoldCostFromCostObject(itemCost.value);
-
-          if (totalGoldCost === 0)
+          if (itemType === "consumable" && encounterLevel < itemLevel)
           {
-            // ignore treasure with 0 cost
             continue;
           }
 
-          if (totalGoldCost <= goldPiecesLeft)
-          {
-            if (itemType === "consumable" && encounterLevel < itemLevel)
-            {
-              continue;
-            }
+          goldPiecesLeft = goldPiecesLeft - totalGoldCost;
 
-            goldPiecesLeft = goldPiecesLeft - totalGoldCost;
-
-            let currentObjectDictionary = {};
-            currentObjectDictionary.quantity = 1;
-            currentObjectDictionary.name = itemName;
-            currentObjectDictionary.object = randomItemObject;
-            itemsResultObject.push(currentObjectDictionary);
-            break;
-          }
+          let currentObjectDictionary = {};
+          currentObjectDictionary.quantity = 1;
+          currentObjectDictionary.name = itemName;
+          currentObjectDictionary.object = randomItemObject;
+          itemsResultObject.push(currentObjectDictionary);
+          break;
         }
       }
-      return itemsResultObject;
     }
+    return itemsResultObject;
+  }
 
-    static getTotalGoldCostFromCostObject(costObject)
-    {
-      let totalGoldCost = 0;
-      totalGoldCost += parseInt(costObject.pp ?? 0) * 10;
-      totalGoldCost += parseInt(costObject.gp ?? 0);
-      totalGoldCost += parseInt(costObject.sp ?? 0) * 0.1;
-      totalGoldCost += parseInt(costObject.cp ?? 0) * 0.01;
-      return totalGoldCost;
-    }
+  static getTotalGoldCostFromCostObject(costObject)
+  {
+    let totalGoldCost = 0;
+    totalGoldCost += parseInt(costObject.pp ?? 0) * 10;
+    totalGoldCost += parseInt(costObject.gp ?? 0);
+    totalGoldCost += parseInt(costObject.sp ?? 0) * 0.1;
+    totalGoldCost += parseInt(costObject.cp ?? 0) * 0.01;
+    return totalGoldCost;
+  }
 
-    static getAdjustedXPString(amountToAdjustEncounter)
+  static getAdjustedXPString(amountToAdjustEncounter)
+  {
+    let plusOrMinus = amountToAdjustEncounter > 0 ? "+" : "";
+    return `Needs ${plusOrMinus}${amountToAdjustEncounter} XP adjustment`;
+  }
+  
+  static isEncounterFormulaPossibleForPlayers(encounterFormula, averageLevelOfPlayers)
+  {
+    // Whole object looks like this.
+    // "Elite Enemies (Severe)": { "EncounterFormula": ["3:0"], "EncounterDifficulty": "Severe" },
+    const formula = encounterFormula.EncounterFormula; 
+
+    for (let formulaPart of formula)
     {
-      let plusOrMinus = amountToAdjustEncounter > 0 ? "+" : "";
-      return `Needs ${plusOrMinus}${amountToAdjustEncounter} XP adjustment`;
+      const creatureDescriptionParts = formulaPart.split(":");
+      const levelInRelationToParty = creatureDescriptionParts[1];
+      const desiredCreatureLevel = parseInt(averageLevelOfPlayers) + parseInt(levelInRelationToParty);
+      if (desiredCreatureLevel < -1)
+      {
+        console.warn(`There are no monsters below requested level for formula. Requested Creature level: ${desiredCreatureLevel}, Average Player Level: ${averageLevelOfPlayers}`);
+        return false;
+      }
     }
+    return true;
+  }
 }

--- a/scripts/utils/EncounterUtils.js
+++ b/scripts/utils/EncounterUtils.js
@@ -1,0 +1,20 @@
+import { SFCONSTS } from "../main.js";
+import { SFLOCALCONSTS } from "../localconst.js";
+import { EncounterUtils5e } from "../dnd5e/EncounterUtils5e.js";
+import { EncounterUtilsPf2e } from "../pf2e/EncounterUtilsPf2e.js";
+import { FoundryUtils } from "./FoundryUtils.js";
+
+export class EncounterUtils
+{
+  static isEncounterFormulaPossibleForPlayers(encounterFormula, averageLevelOfPlayers)
+  {
+    if (FoundryUtils.getSystemId() === "pf2e")
+    {
+        return EncounterUtilsPf2e.isEncounterFormulaPossibleForPlayers(encounterFormula, averageLevelOfPlayers);
+    }
+    else if (FoundryUtils.getSystemId() === "dnd5e")
+    {
+        return EncounterUtilsPf2e.isEncounterFormulaPossibleForPlayers(encounterFormula, averageLevelOfPlayers);
+    }
+  }
+}


### PR DESCRIPTION
![image](https://github.com/etriebe/dnd-randomizer/assets/7503160/d12f306c-c202-45f0-aa3c-23a49edf0513)

If we detect that a formula is impossible because it is requesting creatures for a level that doesn't exist, we'll throw an alert instead of saying to find creatures of that level. 