### PR TITLE
Fix: actor and token image now properly applied. Measured Template Removal after placement

### DIFF
--- a/scripts/encounter.js
+++ b/scripts/encounter.js
@@ -163,14 +163,16 @@ export class Encounter {
 
     let actorData = null;
     let actorType = FoundryUtils.getSystemVariable("LootActorType");
+    let randchestimg = await this.getRandomChestIcon();
     if (FoundryUtils.isFoundryVersion10() || FoundryUtils.isFoundryVersion11())
     {
       actorData = {
         name: this.name || this.id,
         type: actorType,
         texture: {
-          src: await this.getRandomChestIcon(),
+          src: randchestimg,
         },
+        img: randchestimg
         currency: {
           // If Loot sheet is missing use currency as Normal (Adds Support for other NPC Sheets such as TidySheet5e)
           cp: this.currency.cp,

--- a/scripts/encounter.js
+++ b/scripts/encounter.js
@@ -146,6 +146,7 @@ export class Encounter {
         await this.createLootSheet();
       }
       await CreatureSpawner.fromTemplate(template, _this);
+      canvas.scene.deleteEmbeddedDocuments("MeasuredTemplate",[(Array.from(canvas.scene.templates)).pop().id])
       return false;
     });
   }

--- a/scripts/spawner.js
+++ b/scripts/spawner.js
@@ -37,10 +37,13 @@ export class CreatureSpawner {
             canvas.dimensions.distance
           )
         );
-
+        let actorimg = lootActor.img;
         const tokenData = await ActorUtils.getTokenDocument(lootActor, {
           x: position.x,
           y: position.y,
+          texture: {
+            src: actorimg, 
+          },
         });
         tokenData.actorLink = true;
         let lootToken = await canvas.scene.createEmbeddedDocuments("Token", [tokenData]);


### PR DESCRIPTION
Actor gets the random chest icon. The same is then applied during the spawner call. After that the Template gets removed (takes in consideration the last measured template that is in the array).

It may not be the best implementation as i'm fairly new with the API but so far seems to work.

PS: This was tested on D&D 5e only