### PR TITLE
Encounters can now be created through macros

### DIFF
--- a/module.json
+++ b/module.json
@@ -53,9 +53,9 @@
   "minimumCoreVersion": "9",
   "compatibleCoreVersion": "11",
   "url": "https://github.com/etriebe/dnd-randomizer",
-  "changelog": "https://github.com/etriebe/dnd-randomizer/releases/",
-  "manifest": "https://github.com/etriebe/dnd-randomizer/releases/latest/download/module.json",
-  "download": "https://github.com/etriebe/dnd-randomizer/releases/latest/download/module.zip",
+  "changelog": "https://github.com/Drejn/dnd-randomizer/releases/",
+  "manifest": "https://github.com/Drejn/dnd-randomizer/releases/latest/download/module.json",
+  "download": "https://github.com/Drejn/dnd-randomizer/releases/latest/download/module.zip",
   "socket":true,
   "dependencies": [
     {

--- a/module.json
+++ b/module.json
@@ -53,9 +53,9 @@
   "minimumCoreVersion": "9",
   "compatibleCoreVersion": "11",
   "url": "https://github.com/etriebe/dnd-randomizer",
-  "changelog": "https://github.com/Drejn/dnd-randomizer/releases/",
-  "manifest": "https://github.com/Drejn/dnd-randomizer/releases/latest/download/module.json",
-  "download": "https://github.com/Drejn/dnd-randomizer/releases/latest/download/module.zip",
+  "changelog": "https://github.com/etriebe/dnd-randomizer/releases/",
+  "manifest": "https://github.com/etriebe/dnd-randomizer/releases/latest/download/module.json",
+  "download": "https://github.com/etriebe/dnd-randomizer/releases/latest/download/module.zip",
   "socket":true,
   "dependencies": [
     {

--- a/scripts/encounter.js
+++ b/scripts/encounter.js
@@ -25,7 +25,7 @@ export class Encounter {
     this.id = data.id || randomID(40);
   }
   
-  static async generateDynamicEncounter(encounterType,lootType,creatureVariety,encounterDifficulty,spawnLocationX,spawnLocationY,diameter){
+  static async generateDynamicEncounter(encounterType,lootType,creatureVariety,encounterDifficulty,spawnLocationX,spawnLocationY,diameter,monsterTypeFilter){
 
     let numberOfPlayers = 0;
     let averageLevelOfPlayers = 0;
@@ -54,7 +54,7 @@ export class Encounter {
 
     let forceReload = false;
     await SFLocalHelpers.populateObjectsFromCompendiums(forceReload);
-    let filteredMonsters = await SFLocalHelpers.filterMonstersByType("aberration");
+    let filteredMonsters = await SFLocalHelpers.filterMonstersByType(monsterTypeFilter);
     let filteredItems = await SFLocalHelpers.filterItemsFromCompendiums();
     let generateEncounters = await SFLocalHelpers.createDynamicEncounters(filteredMonsters, filteredItems, params);
 

--- a/scripts/encounter.js
+++ b/scripts/encounter.js
@@ -54,7 +54,15 @@ export class Encounter {
 
     let forceReload = false;
     await SFLocalHelpers.populateObjectsFromCompendiums(forceReload);
-    let filteredMonsters = await SFLocalHelpers.filterMonstersByType(monsterTypeFilter);
+    let filteredMonsters;
+    if(monsterTypeFilter === "")
+    {
+      filteredMonsters = await SFLocalHelpers.filterMonstersFromCompendiums();
+    }
+    else{
+      filteredMonsters = await SFLocalHelpers.filterMonstersByType(monsterTypeFilter);
+    }
+    
     let filteredItems = await SFLocalHelpers.filterItemsFromCompendiums();
     let generateEncounters = await SFLocalHelpers.createDynamicEncounters(filteredMonsters, filteredItems, params);
 

--- a/scripts/encounter.js
+++ b/scripts/encounter.js
@@ -54,7 +54,7 @@ export class Encounter {
 
     let forceReload = false;
     await SFLocalHelpers.populateObjectsFromCompendiums(forceReload);
-    let filteredMonsters = await SFLocalHelpers.filterMonstersFromCompendiums();
+    let filteredMonsters = await SFLocalHelpers.filterMonstersByType("aberration");
     let filteredItems = await SFLocalHelpers.filterItemsFromCompendiums();
     let generateEncounters = await SFLocalHelpers.createDynamicEncounters(filteredMonsters, filteredItems, params);
 

--- a/scripts/encounter.js
+++ b/scripts/encounter.js
@@ -25,7 +25,7 @@ export class Encounter {
     this.id = data.id || randomID(40);
   }
   
-  static async generateDynamicEncounter(encounterType,lootType,creatureVariety,encounterDifficulty,spawnLocationX,spawnLocationY){
+  static async generateDynamicEncounter(encounterType,lootType,creatureVariety,encounterDifficulty,spawnLocationX,spawnLocationY,diameter){
 
     let numberOfPlayers = 0;
     let averageLevelOfPlayers = 0;
@@ -64,7 +64,7 @@ export class Encounter {
       x: spawnLocationX,
       y: spawnLocationY,
       direction: 0,
-      distance: 1,
+      distance: diameter,
       borderColor: "#44975C",
       fillColor: "#44975C"
     }]);

--- a/scripts/encounter.js
+++ b/scripts/encounter.js
@@ -71,7 +71,6 @@ export class Encounter {
     const encounterData = await SFHelpers.parseEncounter(generateEncounters, params);
 	
     this.DynamicSpawn(newTemplate[0],encounterData[0]);
-
   }
 
   async prepareData(lootOnly = false) {
@@ -216,9 +215,7 @@ export class Encounter {
       await CreatureSpawner.fromTemplate(template, encounterData);
       canvas.scene.deleteEmbeddedDocuments("MeasuredTemplate",[(Array.from(canvas.scene.templates)).pop().id])
       return false;
-      
   }
-
 
   async getRandomChestIcon() {
     const folder = await FilePicker.browse("public", "icons/containers/chest");

--- a/scripts/encounter.js
+++ b/scripts/encounter.js
@@ -173,7 +173,7 @@ export class Encounter {
         texture: {
           src: randchestimg,
         },
-        img: randchestimg
+        img: randchestimg,
         currency: {
           // If Loot sheet is missing use currency as Normal (Adds Support for other NPC Sheets such as TidySheet5e)
           cp: this.currency.cp,

--- a/scripts/encounter.js
+++ b/scripts/encounter.js
@@ -10,7 +10,7 @@ import { SFLocalHelpers } from "./localmodule.js";
 
 Hooks.once("init", async () => {
   console.log(SFCONSTS.MODULE_NAME + ' | initializing');
-  globalThis.dndrandomizer = Encounter;
+  globalThis.dndrandomizer = Encounter.generateDynamicEncounter;
 });
 
 export class Encounter {

--- a/scripts/encounter.js
+++ b/scripts/encounter.js
@@ -8,10 +8,7 @@ import { ActorUtils } from "./utils/ActorUtils.js";
 import { SFLocalHelpers } from "./localmodule.js";
 
 
-Hooks.once("init", async () => {
-  console.log(SFCONSTS.MODULE_NAME + ' | initializing');
-  globalThis.dndrandomizer = Encounter.generateDynamicEncounter;
-});
+
 
 export class Encounter {
   constructor(data) {
@@ -28,7 +25,7 @@ export class Encounter {
     this.id = data.id || randomID(40);
   }
   
-  async generateDynamicEncounter(encounterType,lootType,creatureVariety,encounterDifficulty,spawnLocationX,spawnLocationY){
+  static async generateDynamicEncounter(encounterType,lootType,creatureVariety,encounterDifficulty,spawnLocationX,spawnLocationY){
 
     let numberOfPlayers = 0;
     let averageLevelOfPlayers = 0;
@@ -40,15 +37,6 @@ export class Encounter {
       averageLevelOfPlayers = activePlayerInfo["averageplayerlevel"];
     }
 
-    /*
-    if (!numberOfPlayers || averageLevelOfPlayers === 0)
-    {
-      numberOfPlayers = html.find('#numberOfPlayers select[name="numberOfPlayers"]').val();
-      averageLevelOfPlayers = html.find('#averageLevelOfPlayers select[name="averageLevelOfPlayers"]').val();
-    }
-    */
-    
-    //const encounterType = html.find('#encounterTypeSpan select[id="encounterTypeSelect"]').val();
     const params = {
       loot_type: lootType,
       encounterType: encounterType,
@@ -59,10 +47,10 @@ export class Encounter {
 
     };
 
-    let encounterTypeObject = EncounterUtils.getEncounterDescriptionObjects();
-    let encounterFormula = encounterTypeObject[encounterType];
+    //let encounterTypeObject = EncounterUtils.getEncounterDescriptionObjects();
+    //let encounterFormula = encounterTypeObject[encounterType];
 
-    const isEncounterFormulaPossible = EncounterUtils.isEncounterFormulaPossibleForPlayers(encounterFormula, averageLevelOfPlayers);
+    //const isEncounterFormulaPossible = EncounterUtils.isEncounterFormulaPossibleForPlayers(encounterFormula, averageLevelOfPlayers);
 
     let forceReload = false;
     await SFLocalHelpers.populateObjectsFromCompendiums(forceReload);
@@ -76,176 +64,14 @@ export class Encounter {
       x: spawnLocationX,
       y: spawnLocationY,
       direction: 0,
-      distance: 20,
+      distance: 1,
       borderColor: "#44975C",
       fillColor: "#44975C"
     }]);
     const encounterData = await SFHelpers.parseEncounter(generateEncounters, params);
-    await _this.populateEncounters(encounterData);
-    CreatureSpawner.DynamicSpawn(newTemplate);
+	
+    this.DynamicSpawn(newTemplate[0],encounterData[0]);
 
-    /*
-    generateEncounters = generateEncounters.sort((a, b) =>
-    {
-      const da = SFCONSTS.DIFFICULTY[a.difficulty.replace(" ", "")];
-      const db = SFCONSTS.DIFFICULTY[b.difficulty.replace(" ", "")];
-      if (da > db) return -1;
-      if (da < db) return 1;
-      return 0;
-    });
-    */
-    
-    /*
-    $button.prop('disabled', false).removeClass('disabled');
-    $button.find('i.fas').removeClass('fa-spinner fa-spin').addClass('fa-dice');
-  
-
-		html.find('.filter-controller select').on('change', function (event)
-		{
-			$(event.currentTarget).closest('.form-encounters').attr('data-show', $(event.currentTarget).val());
-		});
-
-		ModuleUtils.setupFilterBarListeners(html);
-
-		html.find('.filter-controller input').on('keyup change', function (event)
-		{
-			event.preventDefault();
-			const query = $(event.currentTarget).val();
-			const lis = html.find('.form-encounters ul li');
-			let queryIndex = {};
-			let queryElements = [];
-			lis.each((index, li) =>
-			{
-				li = $(li);
-				let encId = li.data("id");
-				let encName = li.find(".encounter-details-header-title").val();
-				queryElements.push(encName);
-				if (queryIndex[encName]) queryIndex[encName].push(encId);
-				else queryIndex[encName] = [encId];
-
-				li.find(".entity-link").each((index, link) =>
-				{
-					let name = $(link).text();
-					queryElements.push(name);
-					if (queryIndex[name]) queryIndex[name].push(encId);
-					else queryIndex[name] = [encId];
-				});
-			});
-			const idsToShow = {};
-			let fs = FuzzySet(queryElements, true);
-			let res = fs.get(query, [], 0.3).map(el => el[1]).forEach((el) =>
-			{
-				queryIndex[el].forEach(id => idsToShow[id] = true);
-			});
-			queryElements.forEach(el =>
-			{
-				if (el.toLowerCase().includes(query.toLowerCase()))
-					queryIndex[el].forEach(id => idsToShow[id] = true);
-			});
-			lis.each((index, li) =>
-			{
-				li = $(li);
-				li.toggleClass('hidden', !(idsToShow[li.data("id")] || !query));
-			});
-
-		});
-
-
-
-		// TODO: CLEAN UP CODE
-		// show and hide styled inputs, update natural language statement
-		html.find('.input-container').click(function ()
-		{
-			var target = $(this);
-			var targetInput = $(this).find('input');
-			var targetSelect = $(this).find('select');
-			var styledSelect = $(this).find('.newSelect');
-			target.addClass('active');
-			targetInput.focus();
-			targetInput.change(function ()
-			{
-				var inputValue = $(this).val();
-				var placeholder = target.find('.placeholder');
-				target.removeClass('active');
-				placeholder.html(inputValue);
-			});
-			targetSelect.change(function ()
-			{
-				var inputValue = $(this).val();
-				var placeholder = target.find('.placeholder');
-				target.removeClass('active');
-				placeholder.html(inputValue);
-			});
-			styledSelect.click(function ()
-			{
-				var target = $(this);
-				setTimeout(function ()
-				{
-					target.parent().parent().removeClass('active');
-				}, 10);
-			});
-		});
-
-		// style selects
-
-		// Create the new select
-		var select = $('.fancy-select');
-		select.wrap('<div class="newSelect"></div>');
-		html.find('.newSelect').prepend('<div class="newOptions"></div>');
-
-		//populate the new select
-		select.each(function ()
-		{
-			var selectOption = $(this).find('option');
-			var target = $(this).parent().find('.newOptions');
-			selectOption.each(function ()
-			{
-				var optionContents = $(this).html();
-				var optionValue = $(this).attr('value');
-				target.append('<div class="newOption" data-value="' + optionValue + '">' + optionContents + '</div>');
-			});
-		});
-		// new select functionality
-		var newSelect = html.find('.newSelect');
-		var newOption = html.find('.newOption');
-		// update based on selection 
-		newOption.on('mouseup', function ()
-		{
-			var OptionInUse = $(this);
-			var siblingOptions = $(this).parent().find('.newOption');
-			var newValue = $(this).attr('data-value');
-			var selectOption = $(this).parent().parent().find('select option');
-			// style selected option
-			siblingOptions.removeClass('selected');
-			OptionInUse.addClass('selected');
-			// update the actual input
-			selectOption.each(function ()
-			{
-				var optionValue = $(this).attr('value');
-				if (newValue == optionValue)
-				{
-					$(this).prop('selected', true);
-				} else
-				{
-					$(this).prop('selected', false);
-				}
-			});
-		});
-		newSelect.click(function ()
-		{
-			var target = $(this);
-			target.parent().find('select').change();
-		});
-
-		// Set Defaults
-		$('#numberOfPlayers .placeholder').text(charData.chars);
-		$('#numberOfPlayers select').val(charData.chars).trigger('change');
-		$(`#numberOfPlayers .newOptions .newOption[data-value="${charData.chars}"]`).addClass('active selected');
-		$('#averageLevelOfPlayers .placeholder').text(charData.level);
-		$('#averageLevelOfPlayers select').val(charData.level);
-		$(`#averageLevelOfPlayers .newOptions .newOption[data-value="${charData.level}"]`).addClass('active selected');
-		$(`#lootType .newOptions .newOption[data-value="Treasure Horde"]`).addClass('active selected');
-    */
   }
 
   async prepareData(lootOnly = false) {
@@ -376,18 +202,21 @@ export class Encounter {
     });
   }
 
-  async DynamicSpawn(template) {
-    await this.loadActors();
-    const _this = this;
-    canvas.tokens.activate();
-    if (this.lootActorId === "")
-    {
-      await this.createLootSheet();
-    }
-    await CreatureSpawner.fromTemplate(template, _this);
-    canvas.scene.deleteEmbeddedDocuments("MeasuredTemplate",[(Array.from(canvas.scene.templates)).pop().id])
-    return false;
+  static async DynamicSpawn(template,encounterData) {
     
+      for (let creature of encounterData.creatures) {
+        await creature.getActor();
+      }
+      const _this = encounterData;
+      canvas.tokens.activate();
+      if (encounterData.lootActorId === "")
+      {
+        await encounterData.createLootSheet();
+      }
+      await CreatureSpawner.fromTemplate(template, encounterData);
+      canvas.scene.deleteEmbeddedDocuments("MeasuredTemplate",[(Array.from(canvas.scene.templates)).pop().id])
+      return false;
+      
   }
 
 

--- a/scripts/localmodule.js
+++ b/scripts/localmodule.js
@@ -592,8 +592,8 @@ export class SFLocalHelpers {
         return !el || el[p.collection] ? true : false;
       });
 
-      const filteredMonsterTypes = [{monsterType}];
-      
+      const filteredMonsterTypes = monsterType;
+
       const filteredEnvironments = Array.from(SFCONSTS.GEN_OPT.environment).filter((e) => {
         const el = savedEnvironmentSettings.find((i) => Object.keys(i)[0] == e);
         return !el || el[e] ? true : false;

--- a/scripts/localmodule.js
+++ b/scripts/localmodule.js
@@ -608,4 +608,28 @@ export class SFLocalHelpers {
       }
       return encounterList;
     }
+
+    static async createDynamicEncounters(monsterList, filteredItems, params)
+    {
+      let averageLevelOfPlayers = params.averageLevelOfPlayers;
+      let numberOfPlayers = params.numberOfPlayers;
+      let currentSystem = game.system.id;
+      let difficulty = params.difficulty;
+      let encounterList = [];
+
+      switch (currentSystem)
+      {
+        case "dnd5e":
+            let currentEncounter = await EncounterUtils5e.createEncounterDnd5e(difficulty, monsterList, averageLevelOfPlayers, numberOfPlayers, params);
+            encounterList.push(currentEncounter);
+          break;
+        case "pf2e":
+          for (let i = 0; i < 30; i++)
+          {
+            let currentEncounter = await EncounterUtilsPf2e.createEncounterPf2e(monsterList, filteredItems, averageLevelOfPlayers, numberOfPlayers, params);
+            encounterList.push(currentEncounter);
+          }
+      }
+      return encounterList;
+    }
 }

--- a/scripts/localmodule.js
+++ b/scripts/localmodule.js
@@ -633,10 +633,6 @@ export class SFLocalHelpers {
       return filteredMonsters;
     }
 
-
-
-
-
     static async createEncounters(monsterList, filteredItems, params, numberOfEncounters)
     {
       let averageLevelOfPlayers = params.averageLevelOfPlayers;

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -5,6 +5,13 @@ import { SFDialog } from "./dialog.js";
 import { CombatEstimateDialog } from "./combatestimatedialog.js";
 import { FoundryUtils } from "./utils/FoundryUtils.js";
 
+
+
+Hooks.once("init", async () => {
+  console.log(MODULE_NAME + ' | initializing');
+  globalThis.StocasticFantastic = StocasticFantastic;
+});
+
 export class SFHelpers {
   static getFolder(type) {
     return game.settings.get(SFCONSTS.MODULE_NAME, `${type}Folder`);

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -7,7 +7,10 @@ import { FoundryUtils } from "./utils/FoundryUtils.js";
 
 
 
-
+Hooks.once("init", async () => {
+  console.log(SFCONSTS.MODULE_NAME + ' | initializing');
+  globalThis.dndrandomizer = Encounter.generateDynamicEncounter;
+});
 
 export class SFHelpers {
   static getFolder(type) {

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -8,7 +8,7 @@ import { FoundryUtils } from "./utils/FoundryUtils.js";
 
 
 Hooks.once("init", async () => {
-  console.log(MODULE_NAME + ' | initializing');
+  console.log(SFCONSTS.MODULE_NAME + ' | initializing');
   globalThis.StocasticFantastic = StocasticFantastic;
 });
 

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -7,10 +7,7 @@ import { FoundryUtils } from "./utils/FoundryUtils.js";
 
 
 
-Hooks.once("init", async () => {
-  console.log(SFCONSTS.MODULE_NAME + ' | initializing');
-  globalThis.SFHelpers = SFHelpers;
-});
+
 
 export class SFHelpers {
   static getFolder(type) {

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -9,7 +9,7 @@ import { FoundryUtils } from "./utils/FoundryUtils.js";
 
 Hooks.once("init", async () => {
   console.log(SFCONSTS.MODULE_NAME + ' | initializing');
-  globalThis.StocasticFantastic = StocasticFantastic;
+  globalThis.SFHelpers = SFHelpers;
 });
 
 export class SFHelpers {

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -9,7 +9,7 @@ import { FoundryUtils } from "./utils/FoundryUtils.js";
 
 Hooks.once("init", async () => {
   console.log(SFCONSTS.MODULE_NAME + ' | initializing');
-  globalThis.dndrandomizer = Encounter.generateDynamicEncounter;
+  globalThis.dndrandomizer = Encounter;
 });
 
 export class SFHelpers {


### PR DESCRIPTION
Here's a macro example to create an encounter:

dndrandomizer.generateDynamicEncounter("Single BBEG","Treasure Horde","Variety of","deadly",150,300,5,"aberration");

Here's a macro example that works by triggering a tile using Monk's Tile Trigger. The args[0] passed is the circle radius, while the tile is automatically passed by the module while the monsterType variable is a a result of a roll table containing the monster type string

dndrandomizer.generateDynamicEncounter("BBEG + 2 Minions","Treasure Horde","Variety of","deadly",tile.x+50,tile.y+50,args[0], Array(tile.document.flags["monks-active-tiles"].variables.monsterType));